### PR TITLE
Add dashboard backend and template

### DIFF
--- a/kmg_autotrader/src/webui/backend.py
+++ b/kmg_autotrader/src/webui/backend.py
@@ -1,10 +1,88 @@
-"""Web backend using FastAPI."""
+"""Web backend using FastAPI.
 
-from fastapi import FastAPI
+This module exposes a minimal REST API used by the web dashboard. The actual
+trading logic is out of scope for this file; instead we provide lightweight
+in-memory stores that tests can interact with.  The endpoints are intentionally
+simple and return JSON structures so the front-end can poll them easily.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, Request
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from src.analysis.performance_analyzer import Trade, compute_metrics
+from src.risk.risk_manager import RiskParameters
+
+
+BASE_PATH = Path(__file__).resolve().parent
 
 app = FastAPI()
 
+# Jinja2 templates and static file mounting -------------------------------
+templates = Jinja2Templates(directory=str(BASE_PATH / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="static")
+
+
+# In-memory stores used for demonstration and unit tests -----------------
+TRADES: List[Trade] = []
+SIGNALS: List[Dict[str, Any]] = []
+REJECTIONS: List[str] = []
+RISK = RiskParameters(max_position_percent=0.5, max_drawdown=10.0)
+LOGS: List[str] = []
+
+
+@app.get("/")
+async def dashboard(request: Request) -> Any:
+    """Render the dashboard template."""
+    equity = [t.pnl for t in TRADES]
+    context = {
+        "request": request,
+        "trades": TRADES,
+        "rejections": REJECTIONS,
+        "equity": equity,
+    }
+    return templates.TemplateResponse("dashboard.html", context)
+
 
 @app.get("/metrics")
-def metrics() -> dict[str, str]:
-    return {"status": "ok"}
+def metrics() -> Dict[str, Any]:
+    """Return basic performance metrics."""
+    return compute_metrics(TRADES)
+
+
+@app.get("/signals")
+def get_signals() -> Dict[str, Any]:
+    """Return latest signals and rejection reasons."""
+    return {"signals": SIGNALS, "rejections": REJECTIONS}
+
+
+@app.get("/risk")
+def get_risk() -> Dict[str, float]:
+    """Return current risk parameters."""
+    return {
+        "max_position_percent": RISK.max_position_percent,
+        "max_drawdown": RISK.max_drawdown,
+    }
+
+
+@app.put("/risk")
+async def update_risk(params: RiskParameters) -> Dict[str, float]:
+    """Update risk parameters."""
+    RISK.max_position_percent = params.max_position_percent
+    RISK.max_drawdown = params.max_drawdown
+    return {
+        "max_position_percent": RISK.max_position_percent,
+        "max_drawdown": RISK.max_drawdown,
+    }
+
+
+@app.get("/logs")
+def get_logs() -> Dict[str, List[str]]:
+    """Return recent log entries."""
+    return {"logs": LOGS}
+

--- a/kmg_autotrader/src/webui/static/css/style.css
+++ b/kmg_autotrader/src/webui/static/css/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+canvas { max-width: 100%; }

--- a/kmg_autotrader/src/webui/static/js/main.js
+++ b/kmg_autotrader/src/webui/static/js/main.js
@@ -1,0 +1,1 @@
+console.log('dashboard loaded');

--- a/kmg_autotrader/src/webui/templates/dashboard.html
+++ b/kmg_autotrader/src/webui/templates/dashboard.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>KMG Dashboard</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>KMG Dashboard</h1>
+    <canvas id="equityChart" width="400" height="200"></canvas>
+
+    <h2>Recent Trades</h2>
+    <ul>
+        {% for trade in trades %}
+        <li>{{ trade }}</li>
+        {% endfor %}
+    </ul>
+
+    <h2>Rejection Reasons</h2>
+    <ul>
+        {% for r in rejections %}
+        <li>{{ r }}</li>
+        {% endfor %}
+    </ul>
+
+    <script>
+    const equity = {{ equity | tojson }};
+    const ctx = document.getElementById('equityChart');
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: equity.map((_, i) => i + 1),
+            datasets: [{
+                label: 'Equity',
+                data: equity,
+                borderColor: 'blue',
+                fill: false
+            }]
+        }
+    });
+    </script>
+    <script src="/static/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- flesh out FastAPI backend with dashboard route and JSON APIs
- serve static assets and Jinja2 template for dashboard
- add simple CSS/JS assets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: asyncpg, openai)*

------
https://chatgpt.com/codex/tasks/task_e_6863bfad97308320914347a887e62dd3