### PR TITLE
Add dependencies

### DIFF
--- a/kmg_autotrader/requirements.txt
+++ b/kmg_autotrader/requirements.txt
@@ -5,3 +5,6 @@ fastapi
 uvicorn
 python-dotenv
 pydantic
+openai
+joblib
+scikit-learn


### PR DESCRIPTION
## Summary
- include OpenAI, Joblib, and scikit-learn in the dependency list

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-binance)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_6863bfa1b5448320946681a988845d0d