### PR TITLE
Implement database-backed metrics

### DIFF
--- a/kmg_autotrader/requirements.txt
+++ b/kmg_autotrader/requirements.txt
@@ -8,3 +8,4 @@ pydantic
 openai
 joblib
 scikit-learn
+SQLAlchemy

--- a/kmg_autotrader/src/db/__init__.py
+++ b/kmg_autotrader/src/db/__init__.py
@@ -1,0 +1,10 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("POSTGRES_URL", "postgresql://localhost/kmg_autotrader")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()

--- a/kmg_autotrader/src/db/models.py
+++ b/kmg_autotrader/src/db/models.py
@@ -1,0 +1,31 @@
+"""Database models used by the application."""
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import Column, DateTime, Enum as SqlEnum, Float, Integer, String
+
+from . import Base
+
+
+class TradeStatus(str, Enum):
+    """Possible trade outcomes."""
+
+    WIN = "WIN"
+    LOSS = "LOSS"
+    REJECTED = "REJECTED"
+
+
+class TradeLog(Base):
+    """Record of an executed or rejected trade."""
+
+    __tablename__ = "trade_log"
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, index=True)
+    symbol = Column(String, nullable=False, index=True)
+    side = Column(String, nullable=False)
+    entry_price = Column(Float, nullable=False)
+    exit_price = Column(Float)
+    pnl = Column(Float)
+    status = Column(SqlEnum(TradeStatus), default=TradeStatus.REJECTED, index=True)

--- a/kmg_autotrader/src/webui/backend.py
+++ b/kmg_autotrader/src/webui/backend.py
@@ -1,11 +1,51 @@
-"""Web backend using FastAPI."""
+"""Web backend using FastAPI.
 
-from fastapi import FastAPI
+Endpoints expose metrics and recent trade signals from the PostgreSQL
+database.  Errors are logged and returned as HTTP 500 responses.
+"""
+
+import logging
+from fastapi import FastAPI, HTTPException
+
+from src.analysis.performance_analyzer import compute_db_metrics
+from src.db import SessionLocal
+from src.db.models import TradeLog
 
 app = FastAPI()
 
 
 @app.get("/metrics")
-def metrics() -> dict[str, str]:
-    """Return basic health metrics for the service."""
-    return {"status": "ok"}
+def metrics() -> dict:
+    """Return performance metrics computed from the database."""
+    try:
+        with SessionLocal() as session:
+            return compute_db_metrics(session)
+    except Exception as exc:  # pragma: no cover - just in case
+        logging.error("Metrics endpoint failed: %s", exc)
+        raise HTTPException(status_code=500, detail="metrics unavailable")
+
+
+@app.get("/signals")
+def signals(limit: int = 10) -> list[dict]:
+    """Return the most recent trade signals."""
+    try:
+        with SessionLocal() as session:
+            trades = (
+                session.query(TradeLog)
+                .order_by(TradeLog.timestamp.desc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                {
+                    "timestamp": t.timestamp.isoformat(),
+                    "symbol": t.symbol,
+                    "side": t.side,
+                    "status": t.status.value,
+                    "pnl": t.pnl,
+                }
+                for t in trades
+            ]
+    except Exception as exc:  # pragma: no cover - just in case
+        logging.error("Signals endpoint failed: %s", exc)
+        raise HTTPException(status_code=500, detail="signals unavailable")


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and session setup
- expand performance analyzer with DB integration and caching
- expose metrics and signals endpoints using DB data
- require SQLAlchemy in dependencies
- handle missing SQLAlchemy gracefully in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863c5c4046c832098fd5e53d8e59cb2