### PR TITLE
Add usage docs and architecture diagram

### DIFF
--- a/how_it_use.txt
+++ b/how_it_use.txt
@@ -1,0 +1,40 @@
+KMG Autotrader requires Python 3.11+, PostgreSQL and access to the Binance and
+OpenAI APIs.  The easiest way to install everything is to run `install.sh` from
+the `kmg_autotrader` directory.  The script installs system packages, creates the
+PostgreSQL database and sets up a virtual environment with all Python
+dependencies.
+
+After installation copy `.env.example` to `.env` and fill in your API keys:
+
+```
+OPENAI_API_KEY=your-openai-key
+BINANCE_API_KEY=your-binance-key
+BINANCE_SECRET_KEY=your-binance-secret
+POSTGRES_URL=postgresql://kmg_user:password@localhost/kmg_autotrader
+TELEGRAM_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-chat-id
+MAX_POSITION_PERCENT=0.2
+MAX_DRAWDOWN=5.0
+GPT_CALL_LIMIT_PER_HOUR=10
+MIN_CONFIDENCE=0.5
+RISK_MODE=normal
+```
+
+Running `python main.py` starts three long running tasks:
+
+1. The **Binance data collector** which stores market data in PostgreSQL.
+2. The **FastAPI web interface** on http://localhost:8000 for monitoring trades
+   and editing risk settings.
+3. A **scheduler** that periodically scans for new signals, updates the ML model
+   and exports performance reports.
+
+Trading on a live Binance account involves real money.  Each order will incur
+exchange fees and, depending on market movements, can lead to losses.  In
+addition, each call to the OpenAI API is billed by OpenAI according to their
+current pricing.  Be sure to keep track of your API usage and only run the bot
+with funds you are prepared to risk.
+
+To run the system in the background you can use `screen`, `tmux` or create a
+simple `systemd` service that executes `python main.py` inside the project
+virtual environment.  Logs from all components are written to the console and to
+the `project_metadata` directory.

--- a/how_it_works.txt
+++ b/how_it_works.txt
@@ -1,0 +1,35 @@
+The KMG Autotrader is organised as a collection of small Python modules under
+`kmg_autotrader/src`.  Each module focuses on a single responsibility and is
+extensively documented with type hints and docstrings.
+
+Overview of the main files:
+
+* **main.py** – starting point that configures all components and launches the
+  scheduler and web server.
+* **src/collector/binance_data_collector.py** – connects to the Binance API,
+  downloads historical candles, subscribes to the WebSocket stream and writes
+  candles to PostgreSQL.
+* **src/evaluator/rule_evaluator.py** – produces basic trading signals from raw
+  market data.  Signals include the asset, direction and a textual reason.
+* **src/trigger/gpt_controller.py** – builds prompts for the OpenAI API,
+  validates the JSON reply against a schema and stores GPT logs.
+* **src/trigger/gpt_trigger.py** – rate‑limits GPT access, combines rule signals
+  with GPT responses and passes validated orders to the risk layer.
+* **src/risk/risk_manager.py** – enforces position limits and drawdown
+  thresholds.  It can automatically switch to a conservative mode if losses
+  accumulate.
+* **src/executor/executor.py** – communicates with Binance using the local
+  `BinanceClient` wrapper, logs orders and alerts on errors.
+* **src/analysis/performance_analyzer.py** – calculates PnL, win rate and
+  drawdown statistics from the trade log stored in PostgreSQL.
+* **src/analysis/ml_trainer.py** – loads past trades, extracts simple features
+  and trains a lightweight ML model to assist the risk manager.
+* **src/webui/backend.py** – FastAPI application serving the dashboard,
+  metrics, risk configuration and logs.
+* **src/scheduler.py** – tiny job scheduler used by `main.py` to periodically
+  check for new signals, update the ML model and export daily reports.
+
+The `project_metadata` directory stores the GPT schema, the trade log database
+and trained ML models.  Configuration values such as API keys and risk
+parameters are read from `.env`.  All modules include logging and graceful error
+handling so that failures in one component do not crash the entire system.

--- a/plantuml.txt
+++ b/plantuml.txt
@@ -1,0 +1,30 @@
+@startuml
+actor Trader
+node "Web UI" as Web
+database PostgreSQL
+cloud Binance
+cloud "OpenAI API" as OpenAI
+component Collector
+component RuleEvaluator
+component GPTTrigger
+component GPTController
+component RiskManager
+component Executor
+component PerformanceAnalyzer
+component MLTrainer
+Trader --> Web : monitor / configure
+Collector --> Binance : price data
+Collector --> PostgreSQL : market_data
+RuleEvaluator --> Collector : candles
+RuleEvaluator --> GPTTrigger : signal
+GPTTrigger --> GPTController : request decision
+GPTController --> OpenAI : prompt
+GPTController --> GPTTrigger : response
+GPTTrigger --> RiskManager : propose order
+RiskManager --> Executor : approved order
+Executor --> Binance : place order
+Executor --> PostgreSQL : trade log
+PostgreSQL --> PerformanceAnalyzer : trades
+MLTrainer --> PostgreSQL : load trades
+Web --> PostgreSQL : metrics
+@enduml


### PR DESCRIPTION
## Summary
- document how the project works
- add instructions for installing and running the bot
- provide a PlantUML architecture diagram

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f0e9b8348320bdb2c89cc56324cf